### PR TITLE
about section text pass contrast requirements

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -97,21 +97,21 @@ main .conf {
 .about-head h1 {
   margin: 5px 0;
   line-height: 2.25rem;
-  font-size: 1.5em;
+  font-size: 1.65em;
   min-width: fit-content;
-  width: 225px;
+  width: 250px;
   text-align: center;
 }
 .conf-about p {
   padding: 15px 20px;
   margin: 5px 10px;
-  font-size: 1.1rem;
-  font-weight: 500;
+  font-size: 1.2rem;
+  font-weight: 600;
   text-align: center;
   line-height: 1.75rem;
 }
 .conf-about p:nth-child(2) {
-  width: 280px;
+  width: 309px;
 }
 .conf-about p:last-of-type {
   margin: 30px 0 10px;
@@ -123,8 +123,8 @@ main .conf {
 }
 .conf-about a.conduct {
   margin: 10px 0 0;
-  font-size: 1.05rem;
-  font-weight: 500;
+  font-size: 1.2rem;
+  font-weight: 600;
   color: #fff;
 }
 .conf-about a.conduct:focus {


### PR DESCRIPTION
Before Change:
![2_0_Accessibility_Text_Contrast_Fix_About_Section_(Before)](https://user-images.githubusercontent.com/5864372/107168234-ad59b580-6980-11eb-8acc-95d30e7fde83.PNG)
After Change:
![2_1_Accessibility_Text_Contrast_Fix_About_Section_(After)](https://user-images.githubusercontent.com/5864372/107168244-b21e6980-6980-11eb-9382-4ae0ea3926f5.PNG)
