### PR TITLE
added text-shadow to about section text for greater contrast

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -101,6 +101,7 @@ main .conf {
   min-width: fit-content;
   width: 250px;
   text-align: center;
+  text-shadow: -2px 2px 6px black;
 }
 .conf-about p {
   padding: 15px 20px;
@@ -109,6 +110,7 @@ main .conf {
   font-weight: 600;
   text-align: center;
   line-height: 1.75rem;
+  text-shadow: -1px 1px 2px black;
 }
 .conf-about p:nth-child(2) {
   width: 309px;


### PR DESCRIPTION
Before Change:
![3_0_Text_Shadow_Contrast_Increase_About_Section_(Before)](https://user-images.githubusercontent.com/5864372/107465892-d157fb00-6b28-11eb-96c6-5c6e5f511311.PNG)
After Change:
![3_1_Text_Shadow_Contrast_Increase_About_Section_(After)](https://user-images.githubusercontent.com/5864372/107465900-d3ba5500-6b28-11eb-8024-63e239816120.PNG)
